### PR TITLE
Skip malformed requests

### DIFF
--- a/aliveim.go
+++ b/aliveim.go
@@ -39,7 +39,11 @@ func notifyDeviceTimerExpired(device_id string) {
 }
 
 func handleAlivePost(rw http.ResponseWriter, request *http.Request) {
-	aliverequest := parseAlivePost(request.Body)
+	aliverequest, err := parseAlivePost(request.Body)
+	if err != nil {
+		log.Printf("ERROR: Couldn't parse request -- %v", err)
+		return
+	}
 	log.Printf("DeviceID: %s, Timeout: %d\n", aliverequest.DeviceID, aliverequest.Timeout)
 
 	timer, timer_found := timers_map[aliverequest.DeviceID]
@@ -56,17 +60,13 @@ func handleAlivePost(rw http.ResponseWriter, request *http.Request) {
 	}
 }
 
-func parseAlivePost(body io.ReadCloser) AliveRequest {
+func parseAlivePost(body io.ReadCloser) (AliveRequest, error) {
 	aliverequest_decoder := json.NewDecoder(body)
 
 	var aliverequest AliveRequest
-	err_aliverequest := aliverequest_decoder.Decode(&aliverequest)
+	err := aliverequest_decoder.Decode(&aliverequest)
 
-	if err_aliverequest != nil {
-		log.Fatalf("Error decoding aliverequest: %s", err_aliverequest)
-	}
-
-	return aliverequest
+	return aliverequest, err
 }
 
 func Handlers() *mux.Router {

--- a/aliveim_test.go
+++ b/aliveim_test.go
@@ -31,7 +31,7 @@ func init() {
 
 func TestParseAlivePost(t *testing.T) {
 	var body io.ReadCloser = nopCloser{strings.NewReader(`{"device_id": "abc123", "timeout": 300}`)}
-	var ar AliveRequest = parseAlivePost(body)
+	ar, _ := parseAlivePost(body)
 
 	if ar.DeviceID != "abc123" || ar.Timeout != 300 {
 		t.Fatalf("Expected: DeviceID: %s, Timeout: %d, got DeviceID: %s, Timeout: %d",
@@ -98,6 +98,19 @@ func TestPostDevicePayloadExistingTimersMap(t *testing.T) {
 		t.Error(err) //Something is wrong while sending request
 	}
 
+	if res.StatusCode != 200 {
+		t.Errorf("Success expected: %d", res.StatusCode) //Uh-oh this means our test failed
+	}
+}
+
+func TestMalformedJSONPayLoad(t *testing.T) {
+	reader := strings.NewReader("") // empty request
+	request, err := http.NewRequest("POST", devicePostUrl, reader)
+	res, err := http.DefaultClient.Do(request)
+
+	if err != nil {
+		t.Error(err) //Something is wrong while sending request
+	}
 	if res.StatusCode != 200 {
 		t.Errorf("Success expected: %d", res.StatusCode) //Uh-oh this means our test failed
 	}


### PR DESCRIPTION
If the server receives a Bad Request it dies with a non-zero return code; instead it should just drop the request and move on:

``` shell
$ go run aliveim.go >error_log 2>&1 &
[1] 26463
$ curl -X POST http://localhost:5000 -d "random_text"
curl: (52) Empty reply from server
$ jobs
[1]+  Exit 1                  go run aliveim.go > error_log 2>&1
$ cat error_log 
2016/02/05 15:09:18 Starting AliveIM service...
2016/02/05 15:09:36 Error decoding aliverequest: invalid character 'r' looking for beginning of value
exit status 1
```

Thanks for considering.
