### PR TITLE
Post to the API server when a device goes on timeout

### DIFF
--- a/aliveim_test.go
+++ b/aliveim_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -21,12 +22,32 @@ func (nopCloser) Close() error { return nil }
 var (
 	server        *httptest.Server
 	reader        io.Reader
-	devicePostUrl string
+	devicePostURL string
 )
+
+func testTools(code int, body string) (*httptest.Server, *Client) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(code)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, body)
+	}))
+
+	transport := &http.Transport{
+		Proxy: func(req *http.Request) (*url.URL, error) {
+			return url.Parse(server.URL)
+		},
+	}
+
+	httpClient := &http.Client{Transport: transport}
+	mockedClient := &Client{httpClient}
+
+	return server, mockedClient
+}
 
 func init() {
 	server = httptest.NewServer(Handlers())
-	devicePostUrl = fmt.Sprintf("%s/", server.URL)
+	devicePostURL = fmt.Sprintf("%s/", server.URL)
+	_, client = testTools(200, `{"status": "ok"}`)
 }
 
 func TestParseAlivePost(t *testing.T) {
@@ -40,22 +61,22 @@ func TestParseAlivePost(t *testing.T) {
 }
 
 func TestCreateTimerInsertMapRetrive(t *testing.T) {
-	var timers_map = make(map[string]DeviceTimer)
+	var timersMap = make(map[string]DeviceTimer)
 	timer := time.NewTimer(time.Second * 2)
-	device_timer := DeviceTimer{"abc123", timer}
-	timers_map["abc123"] = device_timer
-	my_timer := timers_map["abc123"]
+	deviceTimer := DeviceTimer{"abc123", timer}
+	timersMap["abc123"] = deviceTimer
+	myTimer := timersMap["abc123"]
 
-	if my_timer.DeviceID != "abc123" {
-		t.Fatalf("Expected: DeviceID: %s, got DeviceID: %s", "abc123", my_timer.DeviceID)
+	if myTimer.DeviceID != "abc123" {
+		t.Fatalf("Expected: DeviceID: %s, got DeviceID: %s", "abc123", myTimer.DeviceID)
 	}
 }
 
 func TestDeviceTimerStartTimerTimeout(t *testing.T) {
 	timer := time.NewTimer(time.Millisecond * 300)
-	device_timer := DeviceTimer{"abc123", timer}
+	deviceTimer := DeviceTimer{"abc123", timer}
 	fmt.Println("Start timer...")
-	go device_timer.startTimer()
+	go deviceTimer.startTimer()
 	fmt.Println("Sleep 100 ms...")
 	time.Sleep(time.Millisecond * 100)
 	fmt.Println("Sleep 300 ms...")
@@ -64,9 +85,9 @@ func TestDeviceTimerStartTimerTimeout(t *testing.T) {
 }
 
 func TestPostDevicePayloadEmptyTimersMap(t *testing.T) {
-	deviceJson := `{"device_id": "abc123", "timeout": 300}`
-	reader = strings.NewReader(deviceJson)                         //Convert string to reader
-	request, err := http.NewRequest("POST", devicePostUrl, reader) //Create request with JSON body
+	deviceJSON := `{"device_id": "abc123", "timeout": 300}`
+	reader = strings.NewReader(deviceJSON)                         //Convert string to reader
+	request, err := http.NewRequest("POST", devicePostURL, reader) //Create request with JSON body
 
 	res, err := http.DefaultClient.Do(request)
 
@@ -78,19 +99,19 @@ func TestPostDevicePayloadEmptyTimersMap(t *testing.T) {
 		t.Errorf("Success expected: %d", res.StatusCode) //Uh-oh this means our test failed
 	}
 
-	timer, timer_found := timersMap["abc123"]
-	assert.True(t, timer_found)
+	timer, timerFound := timersMap["abc123"]
+	assert.True(t, timerFound)
 	assert.NotNil(t, timer)
 }
 
 func TestPostDevicePayloadExistingTimersMap(t *testing.T) {
 	timer := time.NewTimer(time.Millisecond * time.Duration(300))
-	device_timer := DeviceTimer{"abc123", timer}
-	timersMap["abc123"] = device_timer
+	deviceTimer := DeviceTimer{"abc123", timer}
+	timersMap["abc123"] = deviceTimer
 
-	deviceJson := `{"device_id": "abc123", "timeout": 300}`
-	reader = strings.NewReader(deviceJson)                         //Convert string to reader
-	request, err := http.NewRequest("POST", devicePostUrl, reader) //Create request with JSON body
+	deviceJSON := `{"device_id": "abc123", "timeout": 300}`
+	reader = strings.NewReader(deviceJSON)                         //Convert string to reader
+	request, err := http.NewRequest("POST", devicePostURL, reader) //Create request with JSON body
 
 	res, err := http.DefaultClient.Do(request)
 
@@ -105,7 +126,7 @@ func TestPostDevicePayloadExistingTimersMap(t *testing.T) {
 
 func TestMalformedJSONPayLoad(t *testing.T) {
 	reader := strings.NewReader("") // empty request
-	request, err := http.NewRequest("POST", devicePostUrl, reader)
+	request, err := http.NewRequest("POST", devicePostURL, reader)
 	res, err := http.DefaultClient.Do(request)
 
 	if err != nil {
@@ -114,4 +135,12 @@ func TestMalformedJSONPayLoad(t *testing.T) {
 	if res.StatusCode != 400 {
 		t.Errorf("Failure expected: %d", res.StatusCode) //Uh-oh this means our test failed
 	}
+}
+
+func TestNotifyAPIDeviceTimerExpiredSuccess(t *testing.T) {
+	server, client = testTools(200, `{"status": "ok"}`)
+	defer server.Close()
+
+	err := client.notifyAPIDeviceTimerExpired("abcd1234")
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
This PR finally add the missing code to POST to the notification to the API server. It also introduce a mocked server to properly test the API call without hitting the real server.

reference: http://keighl.com/post/mocking-http-responses-in-golang/
